### PR TITLE
feat: add basic auth to standalone

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,8 +54,14 @@ docker pull ghcr.io/joinmarket-webui/joinmarket-webui-standalone:latest
 ```
 
 ### Environment variables
+The following environment variables control the configuration
+- `ENSURE_WALLET` (optional; create and load the load the wallet in bitcoin core on startup)
+- `READY_FILE` (optional; wait for a file to be created before starting all services, e.g. to wait for chain synchronization)
+- `APP_USER` (optional; default: `joinmarket`; the username used for basic authentication)
+- `APP_PASSWORD` (optional; default: a random 32 char string; the password used for basic authentication)
 
-Variables starting with prefix `JM_` will be applied to `joinmarket.cfg`
+Variables starting with prefix `JM_` will be applied to `joinmarket.cfg` e.g.:
+- `jm_gaplimit: 2000` will set the `gaplimit` config value to `2000`
 
 ### Run
 ```sh

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ docker pull ghcr.io/joinmarket-webui/joinmarket-webui-standalone:latest
 
 ### Environment variables
 The following environment variables control the configuration
-- `ENSURE_WALLET` (optional; create and load the load the wallet in bitcoin core on startup)
+- `ENSURE_WALLET` (optional; create and load the wallet in bitcoin core on startup)
 - `READY_FILE` (optional; wait for a file to be created before starting all services, e.g. to wait for chain synchronization)
 - `APP_USER` (optional; default: `joinmarket`; the username used for basic authentication)
 - `APP_PASSWORD` (optional; default: a random 32 char string; the password used for basic authentication)

--- a/readme.md
+++ b/readme.md
@@ -55,10 +55,10 @@ docker pull ghcr.io/joinmarket-webui/joinmarket-webui-standalone:latest
 
 ### Environment variables
 The following environment variables control the configuration
+- `APP_USER` (required; username used for basic authentication)
+- `APP_PASSWORD` (required; password used for basic authentication)
 - `ENSURE_WALLET` (optional; create and load the wallet in bitcoin core on startup)
 - `READY_FILE` (optional; wait for a file to be created before starting all services, e.g. to wait for chain synchronization)
-- `APP_USER` (optional; default: `joinmarket`; the username used for basic authentication)
-- `APP_PASSWORD` (optional; default: a random 32 char string; the password used for basic authentication)
 
 Variables starting with prefix `JM_` will be applied to `joinmarket.cfg` e.g.:
 - `jm_gaplimit: 2000` will set the `gaplimit` config value to `2000`

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,8 @@ Variables starting with prefix `JM_` will be applied to `joinmarket.cfg` e.g.:
 ```sh
 docker run --rm  -it \
         --add-host=host.docker.internal:host-gateway \
+        --env APP_USER="joinmarket" \
+        --env APP_PASSWORD="joinmarket" \
         --env JM_RPC_HOST="host.docker.internal" \
         --env JM_RPC_PORT="18443" \
         --env JM_RPC_USER="jm" \

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -91,7 +91,6 @@ ENV CONFIG ${DATADIR}/joinmarket.cfg
 ENV DEFAULT_CONFIG /root/default.cfg
 ENV DEFAULT_AUTO_START /root/autostart
 ENV AUTO_START ${DATADIR}/autostart
-ENV ENV_FILE "${DATADIR}/.env"
 ENV PATH /src/scripts:$PATH
 
 RUN ./install.sh --docker-install --without-qt

--- a/standalone/docker-entrypoint.sh
+++ b/standalone/docker-entrypoint.sh
@@ -66,6 +66,17 @@ for key in ${!jmenv[@]}; do
     sed -i "s/^#$key =.*/$key = $val/g" "$CONFIG" || echo "Couldn't set : $key = $val, please modify $CONFIG manually"
 done
 
+BASIC_AUTH_USER=${APP_USER:-joinmarket}
+BASIC_AUTH_PASS=${APP_PASSWORD:-}
+
+if [ "${BASIC_AUTH_PASS}" = "" ]; then
+    BASIC_AUTH_PASS=$(openssl rand -hex 32)
+    echo "Basic auth credentials: user=${BASIC_AUTH_USER} password=${BASIC_AUTH_PASS}"
+fi
+
+echo -e "${BASIC_AUTH_USER}:$(openssl passwd -quiet -6 <<< echo "${BASIC_AUTH_PASS}")\n" > /etc/nginx/.htpasswd
+
+
 if [ "${READY_FILE}" ] && [ "${READY_FILE}" != false ]; then
     echo "Waiting $READY_FILE to be created..."
     while [ ! -f "$READY_FILE" ]; do sleep 1; done

--- a/standalone/docker-entrypoint.sh
+++ b/standalone/docker-entrypoint.sh
@@ -12,6 +12,11 @@ if ! [ -f "$AUTO_START" ]; then
     cp "$DEFAULT_AUTO_START" "$AUTO_START"
 fi
 
+# setup basic authentication
+BASIC_AUTH_USER=${APP_USER:?APP_USER empty or unset}
+BASIC_AUTH_PASS=${APP_PASSWORD:?APP_PASSWORD empty or unset}
+echo -e "${BASIC_AUTH_USER}:$(openssl passwd -quiet -6 <<< echo "${BASIC_AUTH_PASS}")\n" > /etc/nginx/.htpasswd
+
 # generate ssl certificates for jmwalletd
 if ! [ -f "${DATADIR}/ssl/key.pem" ]; then
     subj="/C=US/ST=Utah/L=Lehi/O=Your Company, Inc./OU=IT/CN=example.com"
@@ -66,23 +71,14 @@ for key in ${!jmenv[@]}; do
     sed -i "s/^#$key =.*/$key = $val/g" "$CONFIG" || echo "Couldn't set : $key = $val, please modify $CONFIG manually"
 done
 
-BASIC_AUTH_USER=${APP_USER:-joinmarket}
-BASIC_AUTH_PASS=${APP_PASSWORD:-}
-
-if [ "${BASIC_AUTH_PASS}" = "" ]; then
-    BASIC_AUTH_PASS=$(openssl rand -hex 32)
-    echo "Basic auth credentials: user=${BASIC_AUTH_USER} password=${BASIC_AUTH_PASS}"
-fi
-
-echo -e "${BASIC_AUTH_USER}:$(openssl passwd -quiet -6 <<< echo "${BASIC_AUTH_PASS}")\n" > /etc/nginx/.htpasswd
-
-
+# wait for a ready file to be created if necessary
 if [ "${READY_FILE}" ] && [ "${READY_FILE}" != false ]; then
     echo "Waiting $READY_FILE to be created..."
     while [ ! -f "$READY_FILE" ]; do sleep 1; done
     echo "The chain is fully synched"
 fi
 
+# ensure that a wallet exists and is loaded if necessary
 if [ "${ENSURE_WALLET}" ] && [ "${ENSURE_WALLET}" != false ]; then
     btcuser="${jmenv['rpc_user']}:${jmenv['rpc_password']}"
     btchost="http://${jmenv['rpc_host']}:${jmenv['rpc_port']}"

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -1,4 +1,3 @@
-
 server {
     listen 80;
     listen [::]:80;
@@ -25,7 +24,10 @@ server {
     location /api/ {
         include /etc/nginx/snippets/proxy-params.conf;
 
-        proxy_set_header Authorization "";
+        # jmwalletd expects the bearer token in the Authorization header
+        proxy_set_header Authorization $http_x_jm_authorization;
+        # do not forward the custom authorization header
+        proxy_set_header x-jm-authorization "";
 
         proxy_pass https://127.0.0.1:28183;
     }

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -31,15 +31,4 @@ server {
 
         proxy_pass https://127.0.0.1:28183;
     }
-
-    location /ws/ {
-        include /etc/nginx/snippets/proxy-params.conf;
-
-        proxy_set_header Authorization "";
-
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
-
-        proxy_pass https://127.0.0.1:28183;
-    }
 }

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -7,7 +7,7 @@ server {
     access_log /var/log/nginx/access_joinmarket_webui.log;
     error_log /var/log/nginx/error_joinmarket_webui.log;
 
-    auth_basic "";
+    auth_basic "JoinMarket WebUI";
     auth_basic_user_file /etc/nginx/.htpasswd;
 
     gzip on;

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -7,6 +7,9 @@ server {
     access_log /var/log/nginx/access_joinmarket_webui.log;
     error_log /var/log/nginx/error_joinmarket_webui.log;
 
+    auth_basic "";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
     gzip on;
     gzip_types application/javascript application/json text/css image/svg+xml;
 
@@ -21,11 +24,17 @@ server {
 
     location /api/ {
         include /etc/nginx/snippets/proxy-params.conf;
+
+        proxy_set_header Authorization "";
+
         proxy_pass https://127.0.0.1:28183;
     }
 
     location /ws/ {
         include /etc/nginx/snippets/proxy-params.conf;
+
+        proxy_set_header Authorization "";
+
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $http_connection;
 

--- a/ui-only/nginx/templates/default.conf.template
+++ b/ui-only/nginx/templates/default.conf.template
@@ -24,12 +24,4 @@ server {
         # Proxy API calls to the joinmarket server; the default for the variable is set in jmwebui-entrypoint.sh
         proxy_pass $JMWEBUI_JM_WALLETD_PROXY;
     }
-
-    location /ws/ {
-        include /etc/nginx/snippets/proxy-params.conf;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
-        # Proxy API calls to the joinmarket server; the default for the variable is set in jmwebui-entrypoint.sh
-        proxy_pass $JMWEBUI_JM_WALLETD_PROXY;
-    }
 }


### PR DESCRIPTION
The web UI is served as static content from an nginx webserver. All api requests are proxied to the joinmarket server, but access should be limited as some unauthenticated endpoints contain sensitive information. It seems that the easiest way to keep serving the ui as static files would be Basic Authentication from nginx.

This change adds Basic Authentication to the nginx setup which can be controlled by environment variables `APP_USER` and `APP_PASSWORD`. ~~If no user and password is given, `joinmarket` is used as default user with a generated password logged to stdout~~ Providing these env variables is mandatory.

The current solution only works in conjunction with https://github.com/joinmarket-webui/joinmarket-webui/pull/102
