### PR TITLE
fix: resolve shellcheck warnings

### DIFF
--- a/standalone/docker-entrypoint.sh
+++ b/standalone/docker-entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-export JM_onion_serving_host="$(/sbin/ip route|awk '/src/ { print $9 }')"
+export JM_ONION_SERVING_HOST
+JM_ONION_SERVING_HOST="$(/sbin/ip route|awk '/src/ { print $9 }')"
 
 # First we restore the default cfg as created by wallet-tool.py generate
 if ! [ -f "$CONFIG" ]; then
@@ -30,24 +31,24 @@ fi
 mkdir -p "${DATADIR}/logs"
 
 # auto start services
-while read p; do
+while read -r p; do
     [[ "$p" == "" ]] && continue
     [[ "$p" == "#"* ]] && continue
     echo "Auto start: $p"
     file_path="/etc/supervisor/conf.d/$p.conf"
     if [ -f "$file_path" ]; then
-      sed -i 's/autostart=false/autostart=true/g' $file_path
+      sed -i 's/autostart=false/autostart=true/g' "$file_path"
     else
       echo "$file_path not found"
     fi
-done <$AUTO_START
+done < "$AUTO_START"
 
 declare -A jmenv
 while IFS='=' read -r -d '' envkey parsedval; do
     n="${envkey,,}" # lowercase
     if [[ "$n" =  jm_* ]]; then
         n="${n:3}" # drop jm_
-        jmenv[$n]=${!envkey} # reread environment variable - characters might have been dropped (e.g 'ending in =')
+        jmenv[$n]="${!envkey}" # reread environment variable - characters might have been dropped (e.g 'ending in =')
     fi
 done < <(env -0)
 
@@ -65,8 +66,8 @@ if [ "${jmenv['network']}" == "regtest" ]; then
 fi
 
 # For every env variable JM_FOO=BAR, replace the default configuration value of 'foo' by 'BAR'
-for key in ${!jmenv[@]}; do
-    val=${jmenv[${key}]}
+for key in "${!jmenv[@]}"; do
+    val="${jmenv[${key}]}"
     sed -i "s/^$key =.*/$key = $val/g" "$CONFIG" || echo "Couldn't set : $key = $val, please modify $CONFIG manually"
     sed -i "s/^#$key =.*/$key = $val/g" "$CONFIG" || echo "Couldn't set : $key = $val, please modify $CONFIG manually"
 done

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check for shellcheck warnings in shell scripts.
+
+export LC_ALL=C
+
+# Disabled warnings:
+disabled=(
+    # SC2162 # read without -r will mangle backslashes.
+)
+
+EXIT_CODE=0
+
+if ! command -v shellcheck > /dev/null; then
+    echo "Skipping shell linting since shellcheck is not installed."
+    exit $EXIT_CODE
+fi
+
+SHELLCHECK_CMD=(shellcheck --external-sources --check-sourced --source-path=SCRIPTDIR)
+EXCLUDE="--exclude=$(IFS=','; echo "${disabled[*]}")"
+# Check shellcheck directive used for sourced files
+mapfile -t SOURCED_FILES < <(git ls-files | xargs gawk '/^# shellcheck shell=/ {print FILENAME} {nextfile}')
+mapfile -t FILES < <(git ls-files -- '*.sh')
+if ! "${SHELLCHECK_CMD[@]}" "$EXCLUDE" "${SOURCED_FILES[@]}" "${FILES[@]}"; then
+    EXIT_CODE=1
+fi
+
+exit $EXIT_CODE
+

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -10,7 +10,7 @@ export LC_ALL=C
 
 # Disabled warnings:
 disabled=(
-    # SC2162 # read without -r will mangle backslashes.
+    SC2034 # parsedval appears unused. Verify use (or export if used externally).
 )
 
 EXIT_CODE=0

--- a/ui-only/jmwebui-entrypoint.sh
+++ b/ui-only/jmwebui-entrypoint.sh
@@ -5,7 +5,8 @@ export JMWEBUI_JM_WALLETD_HOST
 export JMWEBUI_JM_WALLETD_PORT
 
 # due to `set -u` this fails if variables are not defined
-export JMWEBUI_JM_WALLETD_PROXY="https://${JMWEBUI_JM_WALLETD_HOST}:${JMWEBUI_JM_WALLETD_PORT}"
+export JMWEBUI_JM_WALLETD_PROXY
+JMWEBUI_JM_WALLETD_PROXY="https://${JMWEBUI_JM_WALLETD_HOST}:${JMWEBUI_JM_WALLETD_PORT}"
 echo "Will proxy requests for /api/* to ${JMWEBUI_JM_WALLETD_PROXY}/*"
 
 # pass on to the original nginx entry point


### PR DESCRIPTION
Add a shellcheck script (taken from [bitcoin-core](https://github.com/bitcoin/bitcoin/blob/master/test/lint/lint-shell.sh)) and resolve warnings.

```
In standalone/docker-entrypoint.sh line 4:
export JM_onion_serving_host="$(/sbin/ip route|awk '/src/ { print $9 }')"
       ^-------------------^ SC2155: Declare and assign separately to avoid masking return values.

In standalone/docker-entrypoint.sh line 33:
while read p; do
      ^--^ SC2162: read without -r will mangle backslashes.

In standalone/docker-entrypoint.sh line 39:
      sed -i 's/autostart=false/autostart=true/g' $file_path
                                                  ^--------^ SC2086: Double quote to prevent globbing and word splitting.

In standalone/docker-entrypoint.sh line 43:
done <$AUTO_START
      ^---------^ SC2086: Double quote to prevent globbing and word splitting.

In standalone/docker-entrypoint.sh line 46:
while IFS='=' read -r -d '' envkey parsedval; do
                                   ^-------^ SC2034: parsedval appears unused. Verify use (or export if used externally).

In standalone/docker-entrypoint.sh line 68:
for key in ${!jmenv[@]}; do
           ^----------^ SC2068: Double quote array expansions to avoid re-splitting elements.
```

`SC2034` is disabled as it is a false positive.