### PR TITLE
devel: add vim and ps to standalone

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -69,7 +69,7 @@ RUN apt-get update \
     && apt-get install -qq --no-install-recommends --no-install-suggests -y \
     # ---
     # image dependencies
-    tini supervisor iproute2 \
+    tini supervisor iproute2 procps vim \
     # servers dependencies (see `install.sh`)
     build-essential automake pkg-config libtool libltdl-dev python3-dev python3-setuptools python3-pip \
     # ui dependencies


### PR DESCRIPTION
Re-adds `vim` and `ps` to `standalone` container.
They have been removed in order to decrease the image size, but they are needed in case anything unexpected happens.