### PR TITLE
fix: autorestart jmwalletd

### DIFF
--- a/standalone/supervisor-conf/jmwalletd.conf
+++ b/standalone/supervisor-conf/jmwalletd.conf
@@ -2,6 +2,7 @@
 directory=/src/scripts
 command=python jmwalletd.py
 autostart=false
+autorestart=true
 stdout_logfile=/root/.joinmarket/logs/jmwalletd_stdout.log
 stdout_logfile_maxbytes=5MB
 stdout_logfile_backups=0


### PR DESCRIPTION
From [supervisord docs](https://supervisord.org/configuration.html?highlight=autorestart):

> autorestart   Specifies if supervisord should automatically restart a process if it exits when it is in the RUNNING state. May be one of false, unexpected, or true. If false, the process will not be autorestarted. 

Default is `unexpected` so services are restarted if they do not exit cleanly. However, `jmwalletd` exited "cleanly" sometimes during testing. Not restarting it would force users to restart jmwalletd manually, which is.. suboptimal for non-power users. 
There is a case for restarting it even without the mentioned behaviour above.

What do you think? Is this a reasonable approach?