### PR TITLE
Proxy websocket connection

### DIFF
--- a/.env
+++ b/.env
@@ -5,5 +5,3 @@ JM_UI_REPO_REF=v0.0.3
 JM_SERVER_REPO=https://github.com/JoinMarket-Org/joinmarket-clientserver
 JM_SERVER_REPO_BRANCH=master
 JM_SERVER_REPO_REF=v0.9.5
-
-JM_UI_REGRESSION_TEST_REPO_REF=v0.0.2

--- a/readme.md
+++ b/readme.md
@@ -16,15 +16,17 @@ docker pull ghcr.io/joinmarket-webui/joinmarket-webui-ui-only:latest
 ### Environment variables
 
 The following environment variables control the configuration
-- `JMWEBUI_JM_WALLETD_HOST` (required; jmwalletd rpc hostname)
-- `JMWEBUI_JM_WALLETD_PORT` (required; jmwalletd rpc port)
+- `JMWEBUI_JMWALLETD_HOST` (required; jmwalletd hostname)
+- `JMWEBUI_JMWALLETD_API_PORT` (required; jmwalletd api port)
+- `JMWEBUI_JMWALLETD_WEBSOCKET_PORT` (required; jmwalletd websocket port)
 
 ### Run
 ```sh
 docker run --rm  -it \
         --add-host=host.docker.internal:host-gateway \
-        --env JMWEBUI_JM_WALLETD_HOST="host.docker.internal" \
-        --env JMWEBUI_JM_WALLETD_PORT="28183" \
+        --env JMWEBUI_JMWALLETD_HOST="host.docker.internal" \
+        --env JMWEBUI_JMWALLETD_API_PORT="28183" \
+        --env JMWEBUI_JMWALLETD_WEBSOCKET_PORT="28283" \
         --publish "8080:80" \
         joinmarket-webui/joinmarket-webui-ui-only
 ```

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -114,7 +114,8 @@ COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 
 # nginx
 EXPOSE 80
-#EXPOSE 28183 # jmwallet daemon
+#EXPOSE 28183 # jmwalletd api
+#EXPOSE 28283 # jmwalletd websocket
 #EXPOSE 8080  # payjoin server
 #EXPOSE 27183 # joinmarketd daemon
 #EXPOSE 62601 # obwatch

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -31,4 +31,16 @@ server {
 
         proxy_pass https://127.0.0.1:28183;
     }
+
+    location /jmws {
+        include /etc/nginx/snippets/proxy-params.conf;
+
+        proxy_http_version 1.1;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Authorization "";
+
+        proxy_pass https://127.0.0.1:28283/;
+    }
 }

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -1,3 +1,16 @@
+
+upstream jmwalletd_api_backend {
+    zone upstreams 64K;
+    server 127.0.0.1:28183;
+    keepalive 16;
+}
+
+upstream jmwalletd_ws_backend {
+    zone upstreams;
+    server 127.0.0.1:28283;
+    keepalive 2;
+}
+
 server {
     listen 80;
     listen [::]:80;
@@ -17,6 +30,7 @@ server {
 
     location / {
         include /etc/nginx/snippets/proxy-params.conf;
+
         try_files $uri $uri/ /index.html;
         add_header Cache-Control no-cache;
     }
@@ -24,12 +38,15 @@ server {
     location /api/ {
         include /etc/nginx/snippets/proxy-params.conf;
 
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
         # jmwalletd expects the bearer token in the Authorization header
         proxy_set_header Authorization $http_x_jm_authorization;
         # do not forward the custom authorization header
         proxy_set_header x-jm-authorization "";
 
-        proxy_pass https://127.0.0.1:28183;
+        proxy_pass https://jmwalletd_api_backend;
     }
 
     location = /jmws {
@@ -41,10 +58,10 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_set_header Authorization "";
 
-        # allow 24h without activity in socket (default is 60 sec)
+        # allow 24h without socket activity (default is 60 sec)
         proxy_read_timeout 86400s;
         proxy_send_timeout 86400s;
 
-        proxy_pass https://127.0.0.1:28283/;
+        proxy_pass https://jmwalletd_ws_backend/;
     }
 }

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -58,9 +58,9 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_set_header Authorization "";
 
-        # allow 24h without socket activity (default is 60 sec)
-        proxy_read_timeout 86400s;
-        proxy_send_timeout 86400s;
+        # allow 10m without socket activity (default is 60 sec)
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
 
         proxy_pass https://jmwalletd_ws_backend/;
     }

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -32,7 +32,7 @@ server {
         proxy_pass https://127.0.0.1:28183;
     }
 
-    location /jmws {
+    location = /jmws {
         include /etc/nginx/snippets/proxy-params.conf;
 
         proxy_http_version 1.1;
@@ -40,6 +40,10 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_set_header Authorization "";
+
+        # allow 24h without activity in socket (default is 60 sec)
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
 
         proxy_pass https://127.0.0.1:28283/;
     }

--- a/ui-only/jmwebui-entrypoint.sh
+++ b/ui-only/jmwebui-entrypoint.sh
@@ -1,13 +1,18 @@
 #!/bin/sh
 set -eu
 
-export JMWEBUI_JM_WALLETD_HOST
-export JMWEBUI_JM_WALLETD_PORT
+export JMWEBUI_JMWALLETD_HOST
+export JMWEBUI_JMWALLETD_API_PORT
+export JMWEBUI_JMWALLETD_WEBSOCKET_PORT
 
 # due to `set -u` this fails if variables are not defined
-export JMWEBUI_JM_WALLETD_PROXY
-JMWEBUI_JM_WALLETD_PROXY="https://${JMWEBUI_JM_WALLETD_HOST}:${JMWEBUI_JM_WALLETD_PORT}"
-echo "Will proxy requests for /api/* to ${JMWEBUI_JM_WALLETD_PROXY}/*"
+export JMWEBUI_JMWALLETD_API_PROXY
+JMWEBUI_JMWALLETD_API_PROXY="${JMWEBUI_JMWALLETD_HOST}:${JMWEBUI_JMWALLETD_API_PORT}"
+echo "Will proxy requests for /api/* to ${JMWEBUI_JMWALLETD_API_PROXY}/api/*"
+
+export JMWEBUI_JMWALLETD_WEBSOCKET_PROXY
+JMWEBUI_JMWALLETD_WEBSOCKET_PROXY="${JMWEBUI_JMWALLETD_HOST}:${JMWEBUI_JMWALLETD_WEBSOCKET_PORT}"
+echo "Will proxy requests for /jmws to ${JMWEBUI_JMWALLETD_WEBSOCKET_PROXY}/"
 
 # pass on to the original nginx entry point
 exec /docker-entrypoint.sh "$@"

--- a/ui-only/nginx/templates/default.conf.template
+++ b/ui-only/nginx/templates/default.conf.template
@@ -1,4 +1,16 @@
 
+upstream jmwalletd_api_backend {
+    zone upstreams 64K;
+    server $JMWEBUI_JMWALLETD_API_PROXY;
+    keepalive 16;
+}
+
+upstream jmwalletd_ws_backend {
+    zone upstreams;
+    server $JMWEBUI_JMWALLETD_WEBSOCKET_PROXY;
+    keepalive 2;
+}
+
 server {
     listen 80;
     listen [::]:80;
@@ -22,12 +34,30 @@ server {
     location /api/ {
         include /etc/nginx/snippets/proxy-params.conf;
 
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
         # jmwalletd expects the bearer token in the Authorization header
         proxy_set_header Authorization $http_x_jm_authorization;
         # do not forward the custom authorization header
         proxy_set_header x-jm-authorization "";
 
-        # Proxy API calls to the joinmarket server; the default for the variable is set in jmwebui-entrypoint.sh
-        proxy_pass $JMWEBUI_JM_WALLETD_PROXY;
+        proxy_pass https://jmwalletd_api_backend;
+    }
+
+    location = /jmws {
+        include /etc/nginx/snippets/proxy-params.conf;
+
+        proxy_http_version 1.1;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Authorization "";
+
+        # allow 24h without socket activity (default is 60 sec)
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+
+        proxy_pass https://jmwalletd_ws_backend/;
     }
 }

--- a/ui-only/nginx/templates/default.conf.template
+++ b/ui-only/nginx/templates/default.conf.template
@@ -54,9 +54,9 @@ server {
         proxy_set_header Connection "upgrade";
         proxy_set_header Authorization "";
 
-        # allow 24h without socket activity (default is 60 sec)
-        proxy_read_timeout 86400s;
-        proxy_send_timeout 86400s;
+        # allow 10m without socket activity (default is 60 sec)
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
 
         proxy_pass https://jmwalletd_ws_backend/;
     }


### PR DESCRIPTION
Companion PR for websocket support. See [related issue in the UI repo](https://github.com/joinmarket-webui/joinmarket-webui/pull/122).


TODO:
- [x] standalone
- [x] ui-only
- [x] testing

Noteably changes:
- Proxies all request to `/jmws` to backend server on port `28283`.

- Use `upstream` directive and add `keepalive` flag - by default, nginx opens a new connection to an proxy server for every new incoming request. Also add `proxy_http_version 1.1` as recommended.
  > By default NGINX uses HTTP/1.0 for connections to upstream servers and accordingly adds the `Connection: close` header to the requests that it forwards to the servers. The result is that each connection gets closed when the request completes, despite the presence of the `keepalive` directive in the `upstream{}` block. [...] Version 1.1 is recommended for use with [keepalive](https://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive) connections

- Increase socket timeouts `proxy_read_timeout` and `proxy_send_timeout` to ~~24 hours~~ 10 minutes - nginx uses 60 seconds by default.
The websocket handling in the app _tries_ to keep the connection alive by sending messages every 30 seconds, but if no wallet is unlocked (hence, no token available), the connection would get closed unnecessarily.