### PR TITLE
config: update to default config for v0.9.6

### DIFF
--- a/standalone/default.cfg
+++ b/standalone/default.cfg
@@ -42,14 +42,64 @@ rpc_password = password
 # information.
 rpc_wallet_file =
 
-## SERVER 1/4) Darkscience IRC (Tor, IP)
+[MESSAGING:onion]
+# onion based message channels must have the exact type 'onion'
+# (while the section name above can be MESSAGING:whatever), and there must
+# be only ONE such message channel configured (note the directory servers
+# can be multiple, below):
+type = onion
+
+socks5_host = localhost
+socks5_port = 9050
+
+# the tor control configuration.
+# for most people running the tor daemon
+# on Linux, no changes are required here:
+tor_control_host = localhost
+# or, to use a UNIX socket
+# tor_control_host = unix:/var/run/tor/control
+# note: port needs to be provided (but is ignored for UNIX socket)
+tor_control_port = 9051
+
+# the host/port actually serving the hidden service
+# (note the *virtual port*, that the client uses,
+# is hardcoded to as per below 'directory node configuration'.
+onion_serving_host = 127.0.0.1
+onion_serving_port = 8080
+
+# directory node configuration
+#
+# This is mandatory for directory nodes (who must also set their
+# own *.onion:port as the only directory in directory_nodes, below),
+# but NOT TO BE USED by non-directory nodes (which is you, unless
+# you know otherwise!), as it will greatly degrade your privacy.
+# (note the default is no value, don't replace it with "").
+hidden_service_dir =
+#
+# This is a comma separated list (comma can be omitted if only one item).
+# Each item has format host:port ; both are required, though port will
+# be 5222 if created in this code.
+# for MAINNET:
+directory_nodes = 3kxw6lf5vf6y26emzwgibzhrzhmhqiw6ekrek3nqfjjmhwznb2moonad.onion:5222,jmdirjmioywe2s5jad7ts6kgcqg66rj6wujj6q77n6wbdrgocqwexzid.onion:5222,bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222
+
+# for SIGNET (testing network):
+# directory_nodes = rr6f6qtleiiwic45bby4zwmiwjrj3jsbmcvutwpqxjziaydjydkk5iad.onion:5222,k74oyetjqgcamsyhlym2vgbjtvhcrbxr4iowd4nv4zk5sehw4v665jad.onion:5222,y2ruswmdbsfl4hhwwiqz4m3sx6si5fr6l3pf62d4pms2b53wmagq3eqd.onion:5222
+
+# This setting is ONLY for developer regtest setups,
+# running multiple bots at once. Don't alter it otherwise
+regtest_count = 0,0
+
+## IRC SERVER 1: Darkscience IRC (Tor, IP)
 ################################################################################
 [MESSAGING:server1]
+# by default the legacy format without a `type` field is
+# understood to be IRC, but you can, optionally, add it:
+# type = irc
 channel = joinmarket-pit
 port = 6697
 usessl = true
 
-# For traditional IP (default):
+# For traditional IP:
 #host = irc.darkscience.net
 #socks5 = false
 
@@ -59,55 +109,33 @@ socks5 = true
 socks5_host = localhost
 socks5_port = 9050
 
-## SERVER 2/4) hackint IRC (Tor, IP)
+## IRC SERVER 2: ILITA IRC (optional IRC alternate, Tor only)
 ################################################################################
 [MESSAGING:server2]
 channel = joinmarket-pit
-
-# For traditional IP (default):
-#host = irc.hackint.org
-#port = 6697
-#usessl = true
-#socks5 = false
-
-# For Tor (recommended as clearnet alternative):
-host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
 port = 6667
 usessl = false
 socks5 = true
 socks5_host = localhost
+
+host = ilitafrzzgxymv6umx2ux7kbz3imyeko6cnqkvy4nisjjj4qpqkrptid.onion
 socks5_port = 9050
 
-## SERVER 3/4) Anarplex IRC (Tor, IP)
+## IRC SERVER 3: (backup) hackint IRC (Tor, IP)
 ################################################################################
-[MESSAGING:server3]
-channel = joinmarket-pit
-
-# For traditional IP (default):
-#host = agora.anarplex.net
-#port = 14716
-#usessl = true
-#socks5 = false
-
-# For Tor (recommended as clearnet alternative):
-host = vxecvd6lc4giwtasjhgbrr3eop6pzq6i5rveracktioneunalgqlwfad.onion
-port = 6667
-usessl = false
-socks5 = true
-socks5_host = localhost
-socks5_port = 9050
-
-## SERVER 4/4) ILITA IRC (Tor - disabled by default)
-################################################################################
-#[MESSAGING:server4]
-#channel = joinmarket-pit
+#[MESSAGING:server3]
+# channel = joinmarket-pit
+# For traditional IP:
+## host = irc.hackint.org
+## port = 6697
+## usessl = true
+## socks5 = false
+# For Tor (default):
+#host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
 #port = 6667
 #usessl = false
 #socks5 = true
 #socks5_host = localhost
-
-# For Tor (recommended):
-#host = ilitafrzzgxymv6umx2ux7kbz3imyeko6cnqkvy4nisjjj4qpqkrptid.onion
 #socks5_port = 9050
 
 [LOGGING]
@@ -259,6 +287,11 @@ interest_rate = 0.015
 # A real number, i.e. 1 = 100%, 0.125 = 1/8 = 1 in every 8 makers on average will be bondless
 bondless_makers_allowance = 0.125
 
+# To (strongly) disincentivize Sybil behaviour, the value assessment of the bond
+# is based on the (time value of the bond)^x where x is the bond_value_exponent here,
+# where x > 1. It is a real number (so written as a decimal).
+bond_value_exponent = 1.3
+
 ##############################
 # THE FOLLOWING SETTINGS ARE REQUIRED TO DEFEND AGAINST SNOOPERS.
 # DON'T ALTER THEM UNLESS YOU UNDERSTAND THE IMPLICATIONS.
@@ -287,6 +320,12 @@ accept_commitment_broadcasts = 1
 # Location of your commitments.json file (stores commitments you've used
 # and those you want to use in future), relative to the scripts directory.
 commit_file_location = cmtdata/commitments.json
+
+# Location of the file used by makers to keep track of used/blacklisted
+# commitments. For remote daemon, set to `.` to have it stored locally
+# (but note that *all* bots using the same code installation share it,
+# in this case, which can be bad in testing).
+commitment_list_location = cmtdata/commitmentlist
 
 ##############################
 # END OF ANTI-SNOOPING SETTINGS
@@ -332,6 +371,7 @@ tor_control_host = localhost
 
 # or, to use a UNIX socket
 # control_host = unix:/var/run/tor/control
+# note: port needs to be provided (but is ignored for UNIX socket)
 tor_control_port = 9051
 
 # the host/port actually serving the hidden service


### PR DESCRIPTION
Closes #31. 

Update to the default config needed for the update to JM v0.9.6. Merge after #30 
This config is currently used in all node integrations and will override any user adaptions.

##### What changed?
[Section `[MESSAGING:onion]`](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/release-notes/release-notes-0.9.6.md#new-p2p-onion-messaging-channels-with-directory-nodes) is new and needed for [onion message channels](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/docs/onion-message-channels.md).
Amount of [default active irc servers](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/044bef6fffd9d33a1a170ccdec82b9fb48c65df3/jmclient/jmclient/configure.py#L191-L238) reduced from 3 to 2.

#### 
Q: Should we enable the third irc server?

[The irc connections are over tor by default in the server now](https://github.com/JoinMarket-Org/joinmarket-clientserver/commit/830ac229345ebb865d2ea2ba5c3bcf6921307ee1) – this has been the reason a custom default config handling has been implemented in the first place. If a third irc server is not enabled, hence making no other changes to the default config than the `max_cj_fee_abs` and `max_cj_fee_rel` values, the whole mechanism could be removed altogether.

There are benefits and drawbacks to each approach. Let me know what you think.