### PR TITLE
fix: increase api request timeout from 60sec to 5min

### DIFF
--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -46,6 +46,12 @@ server {
         # do not forward the custom authorization header
         proxy_set_header x-jm-authorization "";
 
+        # some api requests can take over a minute. play it safe
+        # and allow 5 min (default is 60 sec). increase on demand.
+        proxy_read_timeout 300s;
+        # allow 5 min to connect (default is 60 sec)
+        proxy_connect_timeout 300s;
+
         proxy_pass https://jmwalletd_api_backend;
     }
 

--- a/ui-only/nginx/templates/default.conf.template
+++ b/ui-only/nginx/templates/default.conf.template
@@ -27,6 +27,7 @@ server {
 
     location / {
         include /etc/nginx/snippets/proxy-params.conf;
+
         try_files $uri $uri/ /index.html;
         add_header Cache-Control no-cache;
     }
@@ -41,6 +42,12 @@ server {
         proxy_set_header Authorization $http_x_jm_authorization;
         # do not forward the custom authorization header
         proxy_set_header x-jm-authorization "";
+
+        # some api requests can take over a minute. play it safe
+        # and allow 5 min (default is 60 sec). increase on demand.
+        proxy_read_timeout 300s;
+        # allow 5 min to connect (default is 60 sec)
+        proxy_connect_timeout 300s;
 
         proxy_pass https://jmwalletd_api_backend;
     }


### PR DESCRIPTION
Some requests can take quite a long time, e.g. `/create` can take minutes.
Increasing the timeout to 5min seems to be appropriate as of now.

<img src="https://user-images.githubusercontent.com/3358649/170020473-95db78a2-bf10-493a-8a7d-48de74f8709c.png" width=400 />

