### PR TITLE
build: update nginx from `v1.21.6` to `v1.23.0` in ui-only

### DIFF
--- a/ui-only/Dockerfile
+++ b/ui-only/Dockerfile
@@ -26,7 +26,7 @@ RUN npm install --no-fund --no-audit
 RUN npm run build
 
 # ---
-FROM nginx:1.21.6-alpine as runtime
+FROM nginx:1.23.0-alpine as runtime
 
 # ---
 FROM runtime


### PR DESCRIPTION
Update nginx from `v1.21.6` to `v1.23.0` in ui-only.

No other changes where made.

>  incorporating new features and bug fixes from the mainline branch  — including hardening against potential requests smuggling and cross-protocol attacks, etc.

See the full [changelog](https://nginx.org/en/CHANGES)

