### PR TITLE
dev: add local tor to standalone

### DIFF
--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -101,6 +101,8 @@ RUN mkdir --parents /etc/tor
 RUN ./install.sh --docker-install --with-local-tor --without-qt
 RUN rm -rf install.sh deps/cache/ test/ .git/ .gitignore .github/ .coveragerc joinmarket-qt.desktop
 
+RUN ln /etc/tor/torrc /usr/local/etc/tor/torrc
+
 WORKDIR /src/scripts
 
 COPY .bashrc /root/.bashrc

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -72,6 +72,8 @@ RUN apt-get update \
     tini supervisor iproute2 procps vim \
     # servers dependencies (see `install.sh`)
     build-essential automake pkg-config libtool libltdl-dev python3-dev python3-setuptools python3-pip \
+    # tor dependencies
+    libevent-dev libssl-dev zlib1g-dev \
     # ui dependencies
     nginx \
     # ---
@@ -93,7 +95,10 @@ ENV DEFAULT_AUTO_START /root/autostart
 ENV AUTO_START ${DATADIR}/autostart
 ENV PATH /src/scripts:$PATH
 
-RUN ./install.sh --docker-install --without-qt
+# ensure /etc/tor exists - install script will create /etc/tor/torrc
+RUN mkdir --parents /etc/tor
+
+RUN ./install.sh --docker-install --with-local-tor --without-qt
 RUN rm -rf install.sh deps/cache/ test/ .git/ .gitignore .github/ .coveragerc joinmarket-qt.desktop
 
 WORKDIR /src/scripts

--- a/standalone/Dockerfile
+++ b/standalone/Dockerfile
@@ -95,13 +95,8 @@ ENV DEFAULT_AUTO_START /root/autostart
 ENV AUTO_START ${DATADIR}/autostart
 ENV PATH /src/scripts:$PATH
 
-# ensure /etc/tor exists - install script will create /etc/tor/torrc
-RUN mkdir --parents /etc/tor
-
 RUN ./install.sh --docker-install --with-local-tor --without-qt
 RUN rm -rf install.sh deps/cache/ test/ .git/ .gitignore .github/ .coveragerc joinmarket-qt.desktop
-
-RUN ln /etc/tor/torrc /usr/local/etc/tor/torrc
 
 WORKDIR /src/scripts
 

--- a/standalone/autostart
+++ b/standalone/autostart
@@ -1,6 +1,7 @@
 # Remove comments in front of the services you want to automatically restart
 # when the container restarts.
 
+tor
 nginx
 ob-watcher
 jmwalletd

--- a/standalone/jam-entrypoint.sh
+++ b/standalone/jam-entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-export JM_ONION_SERVING_HOST
-JM_ONION_SERVING_HOST="$(/sbin/ip route|awk '/src/ { print $9 }')"
-
 # ensure 'logs' directory exists
 mkdir --parents "${DATADIR}/logs"
 

--- a/standalone/supervisor-conf/tor.conf
+++ b/standalone/supervisor-conf/tor.conf
@@ -1,0 +1,9 @@
+[program:tor]
+command=/usr/local/bin/tor -f /usr/local/etc/tor/torrc
+autostart=false
+stdout_logfile=/root/.joinmarket/logs/tor_stdout.log
+stdout_logfile_maxbytes=5MB
+stdout_logfile_backups=0
+stderr_logfile=/root/.joinmarket/logs/tor_stderr.log
+stderr_logfile_maxbytes=5MB
+stderr_logfile_backups=0


### PR DESCRIPTION
Closes #43.

**Attention**: This can only be merged when joinmarket-clientserver `v0.9.7` is released (There is a [workaround](https://github.com/joinmarket-webui/joinmarket-webui-docker/pull/44/commits/18d26cadd255c13efe87518f65f16ec753e936c7) that can be applied to make it work with `v0.9.6`).

TBD.

This is still WIP.
