### PR TITLE
feat: opt-in for basic authentication

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,11 +57,11 @@ docker pull ghcr.io/joinmarket-webui/joinmarket-webui-standalone:latest
 
 ### Environment variables
 The following environment variables control the configuration
-- `APP_USER` (required; username used for basic authentication)
-- `APP_PASSWORD` (required; password used for basic authentication)
+- `APP_USER` (optional; username used for basic authentication)
+- `APP_PASSWORD` (optional, but required if `APP_USER` is provided; password used for basic authentication)
 - `ENSURE_WALLET` (optional; create and load the wallet in bitcoin core on startup)
-- `REMOVE_LOCK_FILES` (optional; remove leftover lockfiles from possible unclean shutdowns on startup)
 - `READY_FILE` (optional; wait for a file to be created before starting all services, e.g. to wait for chain synchronization)
+- `REMOVE_LOCK_FILES` (optional; remove leftover lockfiles from possible unclean shutdowns on startup)
 - `RESTORE_DEFAULT_CONFIG` (optional; overwrites any existing `joinmarket.cfg` file the container's default config on startup)
 
 Variables starting with prefix `JM_` will be applied to `joinmarket.cfg` e.g.:

--- a/standalone/jam-entrypoint.sh
+++ b/standalone/jam-entrypoint.sh
@@ -23,9 +23,13 @@ if [ "${REMOVE_LOCK_FILES}" = "true" ]; then
 fi
 
 # setup basic authentication
-BASIC_AUTH_USER=${APP_USER:?APP_USER empty or unset}
-BASIC_AUTH_PASS=${APP_PASSWORD:?APP_PASSWORD empty or unset}
-echo -e "${BASIC_AUTH_USER}:$(openssl passwd -quiet -6 <<< echo "${BASIC_AUTH_PASS}")\n" > /etc/nginx/.htpasswd
+if [ -n "${APP_USER}" ]; then
+    BASIC_AUTH_USER=${APP_USER:?APP_USER empty or unset}
+    BASIC_AUTH_PASS=${APP_PASSWORD:?APP_PASSWORD empty or unset}
+
+    echo -e "${BASIC_AUTH_USER}:$(openssl passwd -quiet -6 <<< echo "${BASIC_AUTH_PASS}")\n" > /etc/nginx/.htpasswd
+    sed -i 's/auth_basic off;/auth_basic "JoinMarket WebUI";/g' /etc/nginx/conf.d/default.conf
+fi
 
 # generate ssl certificates for jmwalletd
 if [ ! -f "${DATADIR}/ssl/key.pem" ]; then

--- a/standalone/nginx/default.conf
+++ b/standalone/nginx/default.conf
@@ -19,7 +19,7 @@ server {
     access_log /var/log/nginx/access_joinmarket_webui.log;
     error_log /var/log/nginx/error_joinmarket_webui.log;
 
-    auth_basic "JoinMarket WebUI";
+    auth_basic off;
     auth_basic_user_file /etc/nginx/.htpasswd;
 
     gzip on;


### PR DESCRIPTION
Resolves #42.

Before this commit, basic authentication was mandatory and enabled by default. Users had to provide env vars `APP_USER` and `APP_PASSWORD`.

After this commit, basic authentication will only be enabled when `APP_USER` has a non-emtpy value. If `APP_USER` is given, `APP_PASSWORD` is mandatory.